### PR TITLE
sync send_to method added

### DIFF
--- a/ecaludp/include/ecaludp/socket.h
+++ b/ecaludp/include/ecaludp/socket.h
@@ -133,7 +133,7 @@ namespace ecaludp
                                     , const asio::ip::udp::endpoint& destination
                                     , const std::function<void(asio::error_code)>& completion_handler);
 
-    ECALUDP_EXPORT std::size_t sync_send_to(const std::vector<asio::const_buffer>& buffer_sequence
+    ECALUDP_EXPORT std::size_t send_to(const std::vector<asio::const_buffer>& buffer_sequence
                                           , const asio::ip::udp::endpoint& destination
                                           , asio::socket_base::message_flags flags
                                           , asio::error_code& ec);

--- a/ecaludp/include/ecaludp/socket.h
+++ b/ecaludp/include/ecaludp/socket.h
@@ -133,6 +133,11 @@ namespace ecaludp
                                     , const asio::ip::udp::endpoint& destination
                                     , const std::function<void(asio::error_code)>& completion_handler);
 
+    ECALUDP_EXPORT std::size_t sync_send_to(const std::vector<asio::const_buffer>& buffer_sequence
+                                          , const asio::ip::udp::endpoint& destination
+                                          , asio::socket_base::message_flags flags
+                                          , asio::error_code& ec);
+
     ECALUDP_EXPORT void set_max_udp_datagram_size(std::size_t max_udp_datagram_size);
     ECALUDP_EXPORT std::size_t get_max_udp_datagram_size() const;
 


### PR DESCRIPTION
In use cases with an own threading model it could make sense to have a synchronously send method. That would simplify the design remarkable.

For eCAL udp send, it would change from this asynchron approach:

```cpp
size_t CSampleSender::Send(const std::string& sample_name_, const std::vector<char>& serialized_sample_)
{
  const unsigned short s1 = static_cast<unsigned short>(sample_name_.size()) + 1 /*'\0'*/;
  const size_t         s2 = serialized_sample_.size();
  const asio::const_buffer sample_name_size_asio_buffer(&s1, 2);
  const asio::const_buffer sample_name_asio_buffer(sample_name_.c_str(), s1); // we need to use c_str() here to guarantee  trailling \'0'
  const asio::const_buffer serialized_sample_asio_buffer(serialized_sample_.data(), s2);

  std::mutex              send_mtx;
  std::condition_variable send_cond;
  bool                    send_finished(false);

  m_socket->async_send_to({ sample_name_size_asio_buffer, sample_name_asio_buffer, serialized_sample_asio_buffer }
    , m_destination_endpoint
    , [this, &send_mtx, &send_cond, &send_finished](asio::error_code ec)
    {
      // triggered by m_socket->cancel in destructor
      if (ec == asio::error::operation_aborted)
      {
        m_socket->close();
        return;
      }

      if (ec)
      {
        std::cout << "CSampleSender: Error sending: " << ec.message() << '\n';
      }

      // notify waiting main thread
      {
        const std::lock_guard<std::mutex> lock(send_mtx);
        send_finished = true;
        send_cond.notify_all();
      }

    });

  // wait for completion handler of async_send_to
  {
    std::unique_lock<std::mutex> lock(send_mtx);
    send_cond.wait(lock, [&send_finished]()->bool {return send_finished; });
  }

  // we return the size of the serialized sample data as "success"
  return s2;
}
```

to this one:

```cpp
size_t CSampleSender::Send(const std::string& sample_name_, const std::vector<char>& serialized_sample_)
    {
      const unsigned short s1 = static_cast<unsigned short>(sample_name_.size()) + 1 /*'\0'*/;
      const size_t         s2 = serialized_sample_.size();
      const asio::const_buffer sample_name_size_asio_buffer(&s1, 2);
      const asio::const_buffer sample_name_asio_buffer(sample_name_.c_str(), s1); // we need to use c_str() here to guarantee  trailling \'0'
      const asio::const_buffer serialized_sample_asio_buffer(serialized_sample_.data(), s2);

      const asio::socket_base::message_flags flags(0);
      asio::error_code ec;
      size_t sent = m_socket->sync_send_to({ sample_name_size_asio_buffer, sample_name_asio_buffer, serialized_sample_asio_buffer }, m_destination_endpoint, flags, ec);
      if (ec)
      {
        std::cout << "CSampleSender::Send failed with: \'" << ec.message() << "\'" << '\n';
        return 0;
      }
      return sent;
    }
```
Besides the simplified implementation of `CSampleSender::Send` we can work without having an extra io_context.