### PR TITLE
feat: Update to asio 1.34.2

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,7 +34,7 @@ jobs:
                  -DECALUDP_USE_BUILTIN_ASIO=ON \
                  -DECALUDP_USE_BUILTIN_RECYCLE=ON \
                  -DECALUDP_USE_BUILTIN_GTEST=ON \
-                 -DCMAKE_CXX_FLAGS=-DASIO_NO_DEPRECATED
+                 -DCMAKE_CXX_FLAGS=-DASIO_NO_DEPRECATED \
                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
       shell: bash
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,6 +34,7 @@ jobs:
                  -DECALUDP_USE_BUILTIN_ASIO=ON \
                  -DECALUDP_USE_BUILTIN_RECYCLE=ON \
                  -DECALUDP_USE_BUILTIN_GTEST=ON \
+                 -DCMAKE_CXX_FLAGS=-DASIO_NO_DEPRECATED
                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
       shell: bash
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         library_type: [static, shared, object]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
 
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -63,6 +63,7 @@ jobs:
                  -DECALUDP_USE_BUILTIN_GTEST=ON \
                  -DECALUDP_LIBRARY_TYPE=${{env.ecaludp_library_type}} \
                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+                 -DCMAKE_CXX_FLAGS=-DASIO_NO_DEPRECATED \
                  -DBUILD_SHARED_LIBS=${{ env.build_shared_libs }}
 
     - name: Build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,8 +9,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   INSTALL_PREFIX: _install
   PROJECT_NAME:   ecaludp
-  VS_TOOLSET:     v140
-  VS_NAME:        vs2015
+  VS_TOOLSET:     v141
+  VS_NAME:        vs2017
 
 jobs:
   build-windows:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -82,6 +82,7 @@ jobs:
                  -DECALUDP_USE_BUILTIN_GTEST=ON ^
                  -DECALUDP_LIBRARY_TYPE=${{env.ecaludp_library_type}} ^
                  -DECALUDP_ENABLE_NPCAP=${{ matrix.npcap_enabled }} ^
+                 -DCMAKE_CXX_FLAGS=/DASIO_NO_DEPRECATED ^
                  -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_PREFIX}}
 
     - name: Build (Release)

--- a/ecaludp/include/ecaludp/socket.h
+++ b/ecaludp/include/ecaludp/socket.h
@@ -46,7 +46,7 @@ namespace ecaludp
   // Constructor
   /////////////////////////////////////////////////////////////////
   public:
-    ECALUDP_EXPORT Socket(asio::io_service& io_service, std::array<char, 4> magic_header_bytes);
+    ECALUDP_EXPORT Socket(asio::io_context& io_context, std::array<char, 4> magic_header_bytes);
 
     // Destructor
     ECALUDP_EXPORT ~Socket();

--- a/ecaludp/include/ecaludp/socket.h
+++ b/ecaludp/include/ecaludp/socket.h
@@ -70,16 +70,16 @@ namespace ecaludp
     std::size_t available(asio::error_code& ec) const                                            { return socket_.available(ec); }
 
     void bind(const asio::ip::udp::endpoint& endpoint)                                           { socket_.bind(endpoint); }
-    asio::error_code bind(const asio::ip::udp::endpoint& endpoint, asio::error_code& ec)         { return socket_.bind(endpoint, ec); }
+    asio::error_code bind(const asio::ip::udp::endpoint& endpoint, asio::error_code& ec)         { socket_.bind(endpoint, ec); return ec; }
 
     void cancel()                                                                                { socket_.cancel(); }
-    asio::error_code cancel(asio::error_code& ec)                                                { return socket_.cancel(ec); }
+    asio::error_code cancel(asio::error_code& ec)                                                { socket_.cancel(ec); return ec;}
 
     void close()                                                                                 { socket_.close(); }
-    asio::error_code close(asio::error_code& ec)                                                 { return socket_.close(ec); }
+    asio::error_code close(asio::error_code& ec)                                                 { socket_.close(ec); return ec; }
 
     void connect(const asio::ip::udp::endpoint& peer_endpoint)                                   { socket_.connect(peer_endpoint); }
-    asio::error_code connect(const asio::ip::udp::endpoint& peer_endpoint, asio::error_code& ec) { return socket_.connect(peer_endpoint, ec); }
+    asio::error_code connect(const asio::ip::udp::endpoint& peer_endpoint, asio::error_code& ec) { socket_.connect(peer_endpoint, ec); return ec; }
 
     const asio::any_io_executor& get_executor()                                                  { return socket_.get_executor(); }
 
@@ -110,7 +110,7 @@ namespace ecaludp
     ASIO_SYNC_OP_VOID native_non_blocking(bool mode, asio::error_code& ec)                       { ASIO_SYNC_OP_VOID_RETURN(socket_.native_non_blocking(mode, ec)); }
 
     void open(const asio::ip::udp& protocol)                                                     { socket_.open(protocol); }
-    asio::error_code open(const asio::ip::udp& protocol, asio::error_code& ec)                   { return socket_.open(protocol, ec); }
+    asio::error_code open(const asio::ip::udp& protocol, asio::error_code& ec)                   { socket_.open(protocol, ec); return ec;}
 
     asio::ip::udp::endpoint remote_endpoint()                     const                          { return socket_.remote_endpoint(); }
     asio::ip::udp::endpoint remote_endpoint(asio::error_code& ec) const                          { return socket_.remote_endpoint(ec); }
@@ -119,10 +119,10 @@ namespace ecaludp
     void set_option(const SettableSocketOption& option)                                          { socket_.set_option(option); }
 
     template<typename SettableSocketOption>
-    asio::error_code set_option(const SettableSocketOption& option, asio::error_code& ec)        { return socket_.set_option(option, ec); }
+    asio::error_code set_option(const SettableSocketOption& option, asio::error_code& ec)        { socket_.set_option(option, ec); return ec;}
 
     void shutdown(asio::socket_base::shutdown_type what)                                         { socket_.shutdown(what); }
-    asio::error_code shutdown(asio::socket_base::shutdown_type what, asio::error_code& ec)       { return socket_.shutdown(what, ec); }
+    asio::error_code shutdown(asio::socket_base::shutdown_type what, asio::error_code& ec)       { socket_.shutdown(what, ec); return ec; }
 
 
   /////////////////////////////////////////////////////////////////

--- a/ecaludp/src/socket.cpp
+++ b/ecaludp/src/socket.cpp
@@ -76,8 +76,8 @@ namespace ecaludp
 
   class recycle_shared_pool : public recycle::shared_pool<ecaludp::RawMemory, buffer_pool_lock_policy_>{};
 
-  Socket::Socket(asio::io_service& io_service, std::array<char, 4> magic_header_bytes)
-    : socket_               (io_service)
+  Socket::Socket(asio::io_context& io_context, std::array<char, 4> magic_header_bytes)
+    : socket_               (io_context)
     , datagram_buffer_pool_ (std::make_unique<ecaludp::recycle_shared_pool>())
     , reassembly_v5_        (std::make_unique<ecaludp::v5::Reassembly>())
     , magic_header_bytes_   (magic_header_bytes)

--- a/samples/ecaludp_perftool/src/receiver_async.cpp
+++ b/samples/ecaludp_perftool/src/receiver_async.cpp
@@ -70,7 +70,7 @@ void ReceiverAsync::start()
 
   receive_message();
 
-  work_ = std::make_unique<asio::io_context::work>(io_context_);
+  work_ = std::make_unique<work_guard_t>(io_context_.get_executor());
 
   io_context_thread_ = std::make_unique<std::thread>([this](){ io_context_.run(); });
 }

--- a/samples/ecaludp_perftool/src/receiver_async.h
+++ b/samples/ecaludp_perftool/src/receiver_async.h
@@ -47,5 +47,6 @@ class ReceiverAsync : public Receiver
     std::unique_ptr<std::thread>            io_context_thread_;
     asio::io_context                        io_context_;
     std::shared_ptr<ecaludp::Socket>        socket_;
-    std::unique_ptr<asio::io_context::work> work_;
+    using work_guard_t = asio::executor_work_guard<asio::io_context::executor_type>;
+    std::unique_ptr<work_guard_t> work_;
 };

--- a/samples/ecaludp_perftool/src/receiver_npcap_sync.cpp
+++ b/samples/ecaludp_perftool/src/receiver_npcap_sync.cpp
@@ -62,7 +62,7 @@ void ReceiverNpcapSync::receive_loop()
     std::exit(1);
   }
 
-  asio::ip::udp::endpoint destination(asio::ip::address::from_string(parameters_.ip), parameters_.port);
+  asio::ip::udp::endpoint destination(asio::ip::make_address(parameters_.ip), parameters_.port);
 
   while (true)
   {

--- a/samples/ecaludp_perftool/src/sender_sync.cpp
+++ b/samples/ecaludp_perftool/src/sender_sync.cpp
@@ -66,7 +66,7 @@ void SenderSync::send_loop()
   }
 
   const std::string message = std::string(parameters_.message_size, 'a');
-  const asio::ip::udp::endpoint destination(asio::ip::address::from_string(parameters_.ip), parameters_.port);
+  const asio::ip::udp::endpoint destination(asio::ip::make_address(parameters_.ip), parameters_.port);
 
   while (true)
   {

--- a/samples/ecaludp_sample/src/main.cpp
+++ b/samples/ecaludp_sample/src/main.cpp
@@ -47,7 +47,7 @@ void send_package()
                               return;
                             }
 
-                            send_timer_->expires_from_now(std::chrono::milliseconds(500));
+                            send_timer_->expires_after(std::chrono::milliseconds(500));
                             send_timer_->async_wait([](asio::error_code ec)
                                                     {
                                                       if (ec)
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
 
   send_timer_ = std::make_shared<asio::steady_timer>(*io_context_);
 
-  asio::io_context::work work(*io_context_);
+  auto work = asio::make_work_guard(*io_context_);
 
   receive_package();
   send_package();

--- a/samples/ecaludp_sample_npcap/src/main.cpp
+++ b/samples/ecaludp_sample_npcap/src/main.cpp
@@ -48,7 +48,7 @@ void send_package()
                               return;
                             }
 
-                            send_timer_->expires_from_now(std::chrono::milliseconds(500));
+                            send_timer_->expires_after(std::chrono::milliseconds(500));
                             send_timer_->async_wait([](asio::error_code ec)
                                                     {
                                                       if (ec)
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
 
   send_timer_ = std::make_shared<asio::steady_timer>(*io_context_);
 
-  asio::io_context::work work(*io_context_);
+  auto work = asio::make_work_guard(*io_context_);
 
   receive_package();
   send_package();

--- a/samples/integration_test/src/main.cpp
+++ b/samples/integration_test/src/main.cpp
@@ -40,7 +40,7 @@ int main()
     socket.bind(asio::ip::udp::endpoint(asio::ip::address_v4::loopback(), 14000), ec);
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();

--- a/tests/ecaludp_npcap_test/src/ecaludp_npcap_socket_test.cpp
+++ b/tests/ecaludp_npcap_test/src/ecaludp_npcap_socket_test.cpp
@@ -74,7 +74,7 @@ TEST(EcalUdpNpcapSocket, AsyncHelloWorldMessage)
     ASSERT_EQ(success, true);
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
@@ -141,7 +141,7 @@ TEST(EcalUdpSocket, AsyncBigMessage)
     ASSERT_EQ(success, true);
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
@@ -210,7 +210,7 @@ TEST(ecalupd, AsyncZeroByteMessage)
     ASSERT_EQ(success, true);
   }
     
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
     
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();

--- a/tests/ecaludp_private_test/src/fragmentation_v5_test.cpp
+++ b/tests/ecaludp_private_test/src/fragmentation_v5_test.cpp
@@ -85,7 +85,7 @@ TEST(FragmentationV5Test, NonFragmentedMessage)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassebly the datagram
@@ -161,7 +161,7 @@ TEST(FragmentationV5Test, FragmentedMessage)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble the first datagram
@@ -234,7 +234,7 @@ TEST(FragmentationV5Test, OutOfOrderFragments)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble the third datagram
@@ -321,7 +321,7 @@ TEST(FragmentationV5Test, SingleFragmentFragmentation)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble the first datagram
@@ -387,7 +387,7 @@ TEST(FragmentationV5Test, ZeroByteMessage)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassebly the datagram
@@ -444,7 +444,7 @@ TEST(FragmentationV5Test, MultiBufferFragmentation)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble the first datagram
@@ -533,7 +533,7 @@ TEST(FragmentationV5Test, MultiBufferWithTailingZeroBuffer)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble all datagrams
@@ -591,7 +591,7 @@ TEST(FragmentationV5Test, Cleanup)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Reassemble the first datagram of the first message
@@ -697,7 +697,7 @@ TEST(FragmentationV5Test, FaultyFragmentedMessages)
 
   // Create a fake sender endpoint as shared_ptr
   auto sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
-  sender_endpoint->address(asio::ip::address::from_string("127.0.0.1"));
+  sender_endpoint->address(asio::ip::make_address("127.0.0.1"));
   sender_endpoint->port(1234);
 
   // Add some way too small fake datagram to the reassembly. This fails, as the datagram cannot even fit a header

--- a/tests/ecaludp_test/src/ecaludp_socket_test.cpp
+++ b/tests/ecaludp_test/src/ecaludp_socket_test.cpp
@@ -51,7 +51,7 @@ TEST(EcalUdpSocket, CancelAsyncReceive)
     ASSERT_EQ(ec, asio::error_code());
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
@@ -102,7 +102,7 @@ TEST(EcalUdpSocket, AsyncHelloWorldMessage)
     ASSERT_EQ(ec, asio::error_code());
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();
@@ -183,7 +183,7 @@ TEST(EcalUdpSocket, AsyncBigMessage)
     ASSERT_FALSE(ec);
   }
 
-  auto work = std::make_unique<asio::io_context::work>(io_context);
+  auto work = asio::make_work_guard(io_context);
   std::thread io_thread([&io_context]() { io_context.run(); });
 
   std::shared_ptr<asio::ip::udp::endpoint> sender_endpoint = std::make_shared<asio::ip::udp::endpoint>();


### PR DESCRIPTION
Updates asio to 1.34.2

Similar to the tcp_pubsub update:

- msvc toolchain had to be bumped up to v141
- CI now doesn't allow the use of deprecated APIs
- Ubuntu 20.04 CI job has been removed and 24.04 added.

